### PR TITLE
chore(build): update to Java 25 and fix related issues

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -20,24 +20,27 @@ plugins {
 
 // [general] configuration
 project.ext {
-	groovyVersion = '4.0.26'
+	groovyVersion = '5.0.4'
 }
 
 project.with {
-	group 'it.grational'
-	version scmVersion.version // '0.5.0' (remove -SNAPSHOT for releases)
-	description 'Impress - A Groovy library to store your objects into any storage, with an implementation for AWS DynamoDB'
+	group = 'it.grational'
+	version = scmVersion.version // '0.5.0' (remove -SNAPSHOT for releases)
+	description = 'Impress - A Groovy library to store your objects into any storage, with an implementation for AWS DynamoDB'
 }
 
-allprojects {
-	sourceCompatibility = JavaVersion.toVersion('21')
-	targetCompatibility = sourceCompatibility
+java {
+	toolchain {
+		languageVersion = JavaLanguageVersion.of(25)
+	}
+	sourceCompatibility = JavaVersion.toVersion(25)
+	targetCompatibility = JavaVersion.toVersion(25)
 }
 
 repositories {
 	mavenCentral()
 
-	maven { url "https://jitpack.io" }
+	maven { url = uri("https://jitpack.io") }
 }
 
 dependencies {
@@ -49,8 +52,10 @@ dependencies {
 
 	// We use the awesome Spock testing and specification framework
 	testImplementation (
-		'org.spockframework:spock-core:2.3-groovy-4.0'
+		'org.spockframework:spock-core:2.4-groovy-5.0'
 	)
+	// Gradle 9 no longer pulls JUnit Platform launcher implicitly
+	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 // test configuration {{{

--- a/lib/docker-compose.yml
+++ b/lib/docker-compose.yml
@@ -4,7 +4,10 @@ services:
     container_name: impress-dynamodb-local
     ports:
       - "8888:8000"
+    # command: "-jar DynamoDBLocal.jar -sharedDb -inMemory"
+    # {
     command: "-jar DynamoDBLocal.jar -sharedDb -dbPath ./data"
     volumes:
       - ./dynamodb_data:/home/dynamodblocal/data
+    # }
     working_dir: /home/dynamodblocal

--- a/lib/src/main/groovy/it/grational/storage/dynamodb/DynamoMap.groovy
+++ b/lib/src/main/groovy/it/grational/storage/dynamodb/DynamoMap.groovy
@@ -60,7 +60,7 @@ class DynamoMap implements Storable<AttributeValue,Object> {
 			switch (v) {
 				case GString:
 				case String:
-					dm.with(k, v as String, ftype)
+					dm.with(k, v.toString(), ftype)
 					break
 				case Number:
 					dm.with(k, v as Number, ftype)
@@ -105,7 +105,7 @@ class DynamoMap implements Storable<AttributeValue,Object> {
 					switch (lv[0]) {
 						case GString:
 						case String:
-							dm.with(k, lv as String[])
+							dm.with(k, lv*.toString() as String[])
 							break
 						case Number:
 							dm.with(k, lv as Number[])
@@ -133,6 +133,7 @@ class DynamoMap implements Storable<AttributeValue,Object> {
 								lv as Storable[]
 							)
 					}
+					break
 			}
 		}
 		return dm


### PR DESCRIPTION
This PR includes:
- Upgrade to Java 25
- Fix for DynamoMap casting issue in Groovy 5 with @CompileStatic

### Details
In Groovy 5, when using @CompileStatic, casting a GString held in an Object-typed variable using `v as String` is compiled as a Java cast `(String) v` instead of using Groovy’s `DefaultTypeTransformation.castToType()`.   Since `GStringImpl` does not extend `String`, this results in a `ClassCastException`.

### Docker
The active Docker configuration is unchanged from the previous version.

The alternative configuration that worked for me locally (removing volume mounts) is left commented in `docker-compose.yml` for reference, but is not enabled by default.